### PR TITLE
feat: add option start upload directly if added to storage

### DIFF
--- a/src/e2e/src/integration/dashboard.spec.ts
+++ b/src/e2e/src/integration/dashboard.spec.ts
@@ -82,6 +82,13 @@ describe("Ngx Fileupload Default View", () => {
 
         beforeEach(async () => {
             await fileBrowser.dropFile("./upload-file.zip");
+
+            /**
+             * ngx-fileupload-storage sends emits after 50ms
+             * so it will not rendered directly and we have to wait for it,
+             * if this is not inserted after 5 seconds timeout
+             */
+            await browser.wait(ngxFileUpload.getUploadItems().isPresent(), 5000);
         });
 
         it("should added ui", async () => {

--- a/src/e2e/src/integration/upload-toolbar.spec.ts
+++ b/src/e2e/src/integration/upload-toolbar.spec.ts
@@ -72,7 +72,7 @@ describe("Ngx Fileupload Upload Toolbar", () => {
         /** start uploads */
         await browser.waitForAngularEnabled(false);
         await uploadToolbar.uploadAll();
-        await browser.sleep(100);
+        await browser.sleep(200);
 
         expect(
             await uploadToolbar.uploadStates.map<string>((state) => state.getText())
@@ -82,6 +82,7 @@ describe("Ngx Fileupload Upload Toolbar", () => {
     it("should contain 3 progressing, 7 pending and 1 idle in info bar", async () => {
         // add another file
         await simulateDrop(ngxFileUpload.getFileBrowser(), "./upload-file.zip");
+        await browser.sleep(200);
 
         expect(
             await uploadToolbar.uploadStates.map<string>((state) => state.getText())

--- a/src/example/app/app.module.ts
+++ b/src/example/app/app.module.ts
@@ -35,6 +35,7 @@ import { CustomizePage } from "@ngx-fileupload-example/page/customize";
 import { Dashboard } from "@ngx-fileupload-example/page/dashboard";
 import { ValidationPage } from "@ngx-fileupload-example/page/validation";
 import { DropZone } from "@ngx-fileupload-example/page/drop-zone";
+import { AutoUploadDemo } from '@ngx-fileupload-example/page/auto-upload';
 
 const fakeUploadProvider: Provider = {
     provide: HTTP_INTERCEPTORS,
@@ -60,6 +61,7 @@ const fakeUploadProvider: Provider = {
         UiModule,
 
         // pages
+        AutoUploadDemo,
         CustomizePage,
         Dashboard,
         ValidationPage,

--- a/src/example/libs/data/base/data.ts
+++ b/src/example/libs/data/base/data.ts
@@ -18,6 +18,7 @@ export interface MenuItem {
 export const MainMenuItems: MenuItem[] = [
     {label: "Dashboard", route: "dashboard"},
     {label: "Customize", route: "customize"},
+    {label: "Automatic Upload", route: "auto-upload"},
     {label: "Ngx File Drop", route: "drop-zone"},
     {label: "Validation", route: "validation"},
 ];

--- a/src/example/libs/pages/auto-upload/index.ts
+++ b/src/example/libs/pages/auto-upload/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/demo.module";

--- a/src/example/libs/pages/auto-upload/src/demo.module.ts
+++ b/src/example/libs/pages/auto-upload/src/demo.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { NgxFileUploadModule } from "@r-hannuschka/ngx-fileupload";
+import { UiModule } from "@ngx-fileupload-example/ui";
+import { DemoComponent } from "./demo/demo";
+
+@NgModule({
+    imports: [
+        NgxFileUploadModule,
+        UiModule,
+        RouterModule.forChild([
+        {
+            path: "auto-upload",
+            component: DemoComponent
+        }
+    ])],
+    exports: [RouterModule],
+    declarations: [DemoComponent],
+    entryComponents: [DemoComponent],
+    providers: [],
+})
+export class AutoUploadDemo { }

--- a/src/example/libs/pages/auto-upload/src/demo/demo.html
+++ b/src/example/libs/pages/auto-upload/src/demo/demo.html
@@ -1,0 +1,1 @@
+<ngx-fileupload [url]="'http://localhost:3000/upload'" [storage]="storage"></ngx-fileupload>

--- a/src/example/libs/pages/auto-upload/src/demo/demo.scss
+++ b/src/example/libs/pages/auto-upload/src/demo/demo.scss
@@ -1,0 +1,18 @@
+$icomoon-font-path: "../../../../../assets/fonts" !default;
+
+@import "variables";
+@import "icons";
+
+:host {
+
+    .header {
+
+        background: map-get($colors, darkBlue);
+        color: map-get($colors, text);
+
+        i {
+            font-size: 12rem;
+            margin: 0 1rem;
+        }
+    }
+}

--- a/src/example/libs/pages/auto-upload/src/demo/demo.ts
+++ b/src/example/libs/pages/auto-upload/src/demo/demo.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { UploadStorage } from "@r-hannuschka/ngx-fileupload";
 
 @Component({

--- a/src/example/libs/pages/auto-upload/src/demo/demo.ts
+++ b/src/example/libs/pages/auto-upload/src/demo/demo.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, Inject } from "@angular/core";
+import { UploadStorage } from "@r-hannuschka/ngx-fileupload";
+
+@Component({
+    selector: "app-dashboard",
+    templateUrl: "demo.html",
+    styleUrls: ["./demo.scss"]
+})
+export class DemoComponent implements OnInit {
+
+    public storage: UploadStorage;
+
+    ngOnInit() {
+        this.storage = new UploadStorage({
+            concurrentUploads: 2,
+            enableAutoStart: true
+        });
+    }
+}

--- a/src/lib/ngx-fileupload/libs/api/src/upload.ts
+++ b/src/lib/ngx-fileupload/libs/api/src/upload.ts
@@ -95,11 +95,13 @@ export interface UploadRequest {
     start(): void;
 }
 
-export interface UploadStoreConfig {
+export interface UploadStorageConfig {
     /**
      * max count of uploads at once, set to -1 for no limit
      */
     concurrentUploads: number;
+
+    enableAutoStart?: boolean;
 }
 
 /**

--- a/src/lib/ngx-fileupload/libs/ui/src/upload-view.ts
+++ b/src/lib/ngx-fileupload/libs/ui/src/upload-view.ts
@@ -98,7 +98,7 @@ export class UploadViewComponent implements OnInit, OnDestroy {
      */
     private registerStoreEvents() {
         this.uploadStorage.change()
-            .pipe(takeUntil(this.destroyed$))
+            .pipe( takeUntil(this.destroyed$))
             .subscribe({
                 next: (uploads) => {
                     this.uploads = uploads;

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.request.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.request.ts
@@ -56,7 +56,7 @@ export class Upload implements UploadRequest {
      * cancel current file upload, this will complete change subject
      */
     public cancel() {
-        if (this.isProgress()) {
+        if (this.isProgress() || this.isPending()) {
             this.upload.state = UploadState.CANCELED;
             this.notifyObservers();
             this.cancel$.next(true);

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
@@ -57,7 +57,7 @@ export class UploadStorage {
             this.registerUploadEvents(request);
         });
 
-        this.afterUploadsAdd();
+        this.afterUploadsAdd(requests);
         this.notifyObserver();
     }
 
@@ -84,9 +84,9 @@ export class UploadStorage {
      * uploads has been added and events are registered
      * finalize operations
      */
-    private afterUploadsAdd(): void {
+    private afterUploadsAdd(requests: UploadRequest[]): void {
         if (this.storeConfig.enableAutoStart) {
-            this.uploads.forEach((uploadRequest) => uploadRequest.start());
+            requests.forEach((uploadRequest) => uploadRequest.start());
         }
     }
 

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
@@ -1,20 +1,11 @@
 import { Observable, Subject, ReplaySubject } from "rxjs";
-import { buffer, debounceTime, takeUntil, distinctUntilKeyChanged, tap, take } from "rxjs/operators";
+import { buffer, takeUntil, distinctUntilKeyChanged, tap, take, auditTime, map } from "rxjs/operators";
 import { UploadQueue } from "./upload.queue";
-import { UploadRequest } from "../../api";
-
-export interface UploadStorageConfig {
-    concurrentUploads?: number;
-
-    autoStart?: boolean;
-
-    /** not implemented yet */
-    removeCompletedUploads?: boolean;
-}
+import { UploadRequest, UploadStorageConfig } from "../../api";
 
 const defaultStoreConfig: UploadStorageConfig = {
     concurrentUploads: 5,
-    autoStart: false
+    enableAutoStart: false
 };
 
 export class UploadStorage {
@@ -28,11 +19,11 @@ export class UploadStorage {
 
     private uploadStateChange$: Subject<void> = new Subject();
 
-    public constructor(config: UploadStorageConfig = {}) {
+    public constructor(config: UploadStorageConfig = null) {
         this.change$     = new ReplaySubject(1);
         this.uploadQueue = new UploadQueue();
 
-        this.storeConfig = {...defaultStoreConfig, ...config};
+        this.storeConfig = {...defaultStoreConfig, ...(config || {})};
         this.uploadQueue.concurrent = this.storeConfig.concurrentUploads;
 
         this.registerUploadStateChanged();
@@ -44,7 +35,10 @@ export class UploadStorage {
      * gets removed or added
      */
     public change(): Observable<UploadRequest[]> {
-        return this.change$.asObservable();
+        return this.change$.pipe(
+            buffer(this.change$.pipe(auditTime(50))),
+            map((changes: UploadRequest[][]) => changes.slice(-1)[0])
+        );
     }
 
     /**
@@ -52,32 +46,48 @@ export class UploadStorage {
      */
     public add(upload: UploadRequest | UploadRequest[]) {
         const requests = Array.isArray(upload) ? upload : [upload];
-        requests.forEach((request: UploadRequest) => {
 
+        requests.forEach((request: UploadRequest) => {
             if (request.requestId && this.uploads.has(request.requestId)) {
                 return;
             }
-
             request.requestId = request.requestId || this.generateUniqeRequestId();
             this.uploads.set(request.requestId, request);
 
-            /** only register for changes if request is not invalid */
-            if (!request.isInvalid()) {
-                this.uploadQueue.register(request);
-                request.change.pipe(
-                    distinctUntilKeyChanged("state"),
-                    takeUntil(request.destroyed),
-                )
-                .subscribe(() => this.uploadStateChange$.next());
-            }
-
-            request.destroyed.pipe(
-                tap(() => this.uploads.delete(request.requestId)),
-                take(1)
-            ).subscribe(() => this.uploadDestroy$.next());
+            this.registerUploadEvents(request);
         });
 
+        this.afterUploadsAdd();
         this.notifyObserver();
+    }
+
+    /**
+     * register for changes and destroy on upload request
+     */
+    private registerUploadEvents(request: UploadRequest): void {
+        if (!request.isInvalid()) {
+            this.uploadQueue.register(request);
+            request.change.pipe(
+                distinctUntilKeyChanged("state"),
+                takeUntil(request.destroyed),
+            )
+            .subscribe(() => this.uploadStateChange$.next());
+        }
+
+        request.destroyed.pipe(
+            tap(() => this.uploads.delete(request.requestId)),
+            take(1)
+        ).subscribe(() => this.uploadDestroy$.next());
+    }
+
+    /**
+     * uploads has been added and events are registered
+     * finalize operations
+     */
+    private afterUploadsAdd(): void {
+        if (this.storeConfig.enableAutoStart) {
+            this.uploads.forEach((uploadRequest) => uploadRequest.start());
+        }
     }
 
     /**
@@ -175,12 +185,11 @@ export class UploadStorage {
      * idle to pending
      */
     private registerUploadStateChanged() {
-        this.uploadStateChange$.pipe(
-            buffer(this.uploadStateChange$.pipe(debounceTime(10))),
-            takeUntil(this.destroyed$)
-        ).subscribe({
-            next: () => this.notifyObserver()
-        });
+        this.uploadStateChange$
+            .pipe(takeUntil(this.destroyed$))
+            .subscribe({
+                next: () => this.notifyObserver()
+            });
     }
 
     /**
@@ -189,20 +198,17 @@ export class UploadStorage {
      * and then remove them from list and notify observer
      */
     private registerUploadDestroyEvent() {
-        this.uploadDestroy$.pipe(
-            buffer(this.uploadDestroy$.pipe(debounceTime(10))),
-            takeUntil(this.destroyed$)
-        ).subscribe({
-            next: () => this.notifyObserver()
-        });
+        this.uploadDestroy$
+            .pipe(takeUntil(this.destroyed$))
+            .subscribe({
+                next: () => this.notifyObserver()
+            });
     }
 
     /**
      * notify observer store data has been changed
      */
     private notifyObserver() {
-        this.change$.next(
-            Array.from(this.uploads.values())
-        );
+        this.change$.next(Array.from(this.uploads.values()));
     }
 }

--- a/src/lib/tests/libs/upload/upload.storage.spec.ts
+++ b/src/lib/tests/libs/upload/upload.storage.spec.ts
@@ -1,6 +1,6 @@
 import { UploadStorage, UploadState } from "@r-hannuschka/ngx-fileupload";
 import { UploadRequestMock, UploadModel } from "../../mockup";
-import { take, skip, takeWhile, tap } from "rxjs/operators";
+import { take, takeWhile, tap } from "rxjs/operators";
 
 describe("ngx-fileupload/libs/upload/upload.storage", () => {
 
@@ -64,7 +64,7 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         spyOn(uploadRequest1, "destroy").and.callFake(() => uploadRequest1.destroy$.next(true));
 
         storage.change()
-            .pipe(skip(1), take(1))
+            .pipe(take(1))
             .subscribe({
                 next: (requests) => expect(requests).toEqual([uploadRequest2]),
                 complete: () => done()
@@ -82,7 +82,7 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         spyOn(uploadRequest1, "destroy").and.callFake(() => uploadRequest1.destroy$.next(true));
 
         storage.change()
-            .pipe(skip(1), take(1))
+            .pipe(take(1))
             .subscribe({
                 next: (requests) => expect(requests).toEqual([uploadRequest2]),
                 complete: () => done()
@@ -102,7 +102,7 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         const uploadRequest3 = new UploadRequestMock(fileUpload3);
 
         storage.change()
-            .pipe(skip(1), take(1))
+            .pipe(take(1))
             .subscribe({
                 next: (requests) => expect(requests).toEqual([uploadRequest3]),
                 complete: () => done()
@@ -130,7 +130,7 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         const startSpyUR3 = spyOn(uploadRequest3, "start").and.callFake(() => uploadRequest3.change$.next());
 
         storage.change()
-            .pipe(skip(1), take(1))
+            .pipe(take(1))
             .subscribe({
                 complete: () =>  {
                     expect(startSpyUR1).not.toHaveBeenCalled();
@@ -154,7 +154,7 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         const uploadRequest2 = new UploadRequestMock(fileUpload2);
 
         storage.change()
-            .pipe(skip(1), take(1))
+            .pipe(take(1))
             .subscribe({
                 next: (requests) => expect(requests).toEqual([uploadRequest2]),
                 complete: () => done()
@@ -168,7 +168,6 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
 
     it ("should not register to changes of invalid uploads", (done) => {
         const fileUpload1 = new UploadModel();
-
         const uploadRequest1 = new UploadRequestMock(fileUpload1);
         uploadRequest1.requestId = "dontRegisterToInvalid";
 
@@ -176,7 +175,6 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
 
         storage.change()
             .pipe(
-                skip(1), // this is add
                 tap(() => changeSpy()),
                 takeWhile((requests) => requests.length > 0)
             )
@@ -191,5 +189,27 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         storage.add([uploadRequest1]);
         uploadRequest1.change$.next();
         uploadRequest1.destroy();
+    });
+
+    it ("should start uploads automatically", (done) => {
+
+        const autoStartStorage = new UploadStorage({
+            concurrentUploads: 1,
+            enableAutoStart: true
+        });
+
+        const fileUpload1 = new UploadModel();
+        const uploadRequest1 = new UploadRequestMock(fileUpload1);
+
+        autoStartStorage.change()
+            .pipe(take(1))
+            .subscribe({
+                complete: () => {
+                    expect(uploadRequest1.isProgress()).toBeTruthy();
+                    done();
+                }
+            });
+
+        autoStartStorage.add(uploadRequest1);
     });
 });

--- a/src/server/upload-server.js
+++ b/src/server/upload-server.js
@@ -5,6 +5,7 @@ const resolve = require("path").resolve;
 const dirname = require("path").dirname;
 const letsLog = require("letslog");
 const fileUpload = require("express-fileupload");
+
 const logger = new letsLog.Logger({
     baseComment: "",
     loglvl: letsLog.ELoglevel.DEBUG,
@@ -46,7 +47,6 @@ app.use(function(req, res, next) {
 app.use(fileUpload());
 
 app.post("/upload", function(req, res) {
-
     const uploadedFile = req.files.file;
     logger.info(`File uploaded: ${uploadedFile.name}`);
 


### PR DESCRIPTION
added additional configuration parameter

```
export interface UploadStorageConfig {
    concurrentUploads: number;
    enableAutoStart?: boolean;
}
```

by default this is false, if set to true it will start uploads directly if added to upload storage. 
To avoid multiple change emits on UploadStorage we buffer all changes which will made on storage now for 50ms.

closes #163