### PR TITLE
feat: auto remove uploads after given amount of time

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -151,6 +151,8 @@ interface UploadStorageConfig {
     concurrentUploads?: number;
 
     enableAutoUpload?: boolean;
+
+    removeCompleted?: number;
 }
 ```
 

--- a/src/lib/ngx-fileupload/libs/api/src/upload.ts
+++ b/src/lib/ngx-fileupload/libs/api/src/upload.ts
@@ -109,8 +109,15 @@ export interface UploadStorageConfig {
      * max count of uploads at once, set to -1 for no limit
      */
     concurrentUploads: number;
-
+    /**
+     * if set to true it will automatically starts uploads
+     */
     enableAutoStart?: boolean;
+    /**
+     * if set it will remove success full completed uploads after a specific
+     * amount of time.
+     */
+    removeCompleted?: number;
 }
 
 /**

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
@@ -5,8 +5,7 @@ import { UploadQueue } from "./upload.queue";
 
 const defaultStoreConfig: UploadStorageConfig = {
     concurrentUploads: 5,
-    enableAutoStart: false,
-    removeCompleted: 5000
+    enableAutoStart: false
 };
 
 export class UploadStorage {

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
@@ -1,5 +1,5 @@
-import { Observable, Subject, ReplaySubject, of, timer } from "rxjs";
-import { buffer, takeUntil, distinctUntilKeyChanged, tap, take, auditTime, map, delay, filter, switchMap } from "rxjs/operators";
+import { Observable, Subject, ReplaySubject, timer } from "rxjs";
+import { buffer, takeUntil, distinctUntilKeyChanged, tap, take, auditTime, map, filter, switchMap } from "rxjs/operators";
 import { UploadRequest, UploadStorageConfig, FileUpload, UploadState } from "../../api";
 import { UploadQueue } from "./upload.queue";
 

--- a/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
+++ b/src/lib/ngx-fileupload/libs/upload/src/upload.storage.ts
@@ -1,7 +1,7 @@
 import { Observable, Subject, ReplaySubject } from "rxjs";
-import { buffer, takeUntil, distinctUntilKeyChanged, tap, take, auditTime, map } from "rxjs/operators";
+import { buffer, takeUntil, distinctUntilKeyChanged, tap, take, auditTime, map, delay, filter } from "rxjs/operators";
+import { UploadRequest, UploadStorageConfig, FileUpload, UploadState } from "../../api";
 import { UploadQueue } from "./upload.queue";
-import { UploadRequest, UploadStorageConfig } from "../../api";
 
 const defaultStoreConfig: UploadStorageConfig = {
     concurrentUploads: 5,
@@ -65,19 +65,41 @@ export class UploadStorage {
      * register for changes and destroy on upload request
      */
     private registerUploadEvents(request: UploadRequest): void {
+
         if (!request.isInvalid()) {
             this.uploadQueue.register(request);
-            request.change.pipe(
-                distinctUntilKeyChanged("state"),
-                takeUntil(request.destroyed),
-            )
-            .subscribe(() => this.uploadStateChange$.next());
+            this.handleRequestChange(request);
         }
 
         request.destroyed.pipe(
             tap(() => this.uploads.delete(request.requestId)),
             take(1)
         ).subscribe(() => this.uploadDestroy$.next());
+    }
+
+    /**
+     * register to request change events, this will notify all observers
+     * if state from upload state has been changed, this will not notify
+     * if amount of uploaded size has been changed
+     */
+    private handleRequestChange(request: UploadRequest) {
+        const isAutoRemove = !isNaN(this.storeConfig.removeCompleted) || false;
+
+        request.change.pipe(
+            distinctUntilKeyChanged("state"),
+            /* notify observers upload state has been changed */
+            tap(() => this.uploadStateChange$.next()),
+            /* only continue if completed with no errors and autoremove is enabled */
+            filter((upload: FileUpload) => upload.state === UploadState.COMPLETED && !upload.hasError && isAutoRemove),
+            /* delay response by given number on remove completed and then remove it automatically */
+            delay(this.storeConfig.removeCompleted),
+            /* automatically unsubscribe if request gets destroyed */
+            takeUntil(request.destroyed),
+        )
+        .subscribe({
+            next: () => this.remove(request),
+            complete: () => console.log("completed")
+        });
     }
 
     /**

--- a/src/lib/tests/libs/upload/upload.storage.spec.ts
+++ b/src/lib/tests/libs/upload/upload.storage.spec.ts
@@ -126,8 +126,8 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
         const uploadRequest3 = new UploadRequestMock(fileUpload3);
 
         const startSpyUR1 = spyOn(uploadRequest1, "start").and.callFake(() => void 0);
-        const startSpyUR2 = spyOn(uploadRequest2, "start").and.callFake(() => uploadRequest2.change$.next());
-        const startSpyUR3 = spyOn(uploadRequest3, "start").and.callFake(() => uploadRequest3.change$.next());
+        const startSpyUR2 = spyOn(uploadRequest2, "start").and.callFake(() => uploadRequest2.change$.next(uploadRequest2.uploadFile));
+        const startSpyUR3 = spyOn(uploadRequest3, "start").and.callFake(() => uploadRequest3.change$.next(uploadRequest3.uploadFile));
 
         storage.change()
             .pipe(take(1))

--- a/src/lib/tests/libs/upload/upload.storage.spec.ts
+++ b/src/lib/tests/libs/upload/upload.storage.spec.ts
@@ -1,6 +1,6 @@
 import { UploadStorage, UploadState } from "@r-hannuschka/ngx-fileupload";
 import { UploadRequestMock, UploadModel } from "../../mockup";
-import { take, takeWhile, tap } from "rxjs/operators";
+import { take, takeWhile, tap, skip } from "rxjs/operators";
 
 describe("ngx-fileupload/libs/upload/upload.storage", () => {
 
@@ -211,5 +211,28 @@ describe("ngx-fileupload/libs/upload/upload.storage", () => {
             });
 
         autoStartStorage.add(uploadRequest1);
+    });
+
+    it ("should remove completed uploads after 1 second", (done) => {
+
+        const autoStartStorage = new UploadStorage({
+            concurrentUploads: 1,
+            enableAutoStart: false,
+            removeCompleted: 1000
+        });
+
+        const fileUpload = new UploadModel();
+        const uploadRequest = new UploadRequestMock(fileUpload);
+
+        autoStartStorage.change()
+            .pipe(skip(1), take(1))
+            .subscribe({
+                next: (req: UploadRequestMock[]) => expect(req).toEqual([]),
+                complete: () => done()
+            });
+
+        autoStartStorage.add(uploadRequest);
+        uploadRequest.uploadFile.state = UploadState.COMPLETED;
+        uploadRequest.applyChange();
     });
 });

--- a/src/lib/tests/mockup/src/upload-request.mock.ts
+++ b/src/lib/tests/mockup/src/upload-request.mock.ts
@@ -84,6 +84,6 @@ export class UploadRequestMock implements UploadRequest {
     }
 
     public applyChange() {
-        this.change$.next(this.uploadFile);
+        this.change$.next({...this.uploadFile});
     }
 }


### PR DESCRIPTION
if removeCompleted is set in storage configuration it will now remove
completed uploads which gets not error after given amount of time.

@example remove completed uploads after 5 secs automacially

```ts
const config: UploadStorageConfig = {
    concurrentUploads: 2,
    removeCompleted: 5000
}
```

closes #174