### PR TITLE
Feat: Add support for withCredentials on requests

### DIFF
--- a/docs/core/api.md
+++ b/docs/core/api.md
@@ -1,7 +1,7 @@
 
-# API 
+# API
 
-## FileUploadItemContext 
+## FileUploadItemContext
 
 ```
 export interface FileUploadItemContext {
@@ -150,6 +150,11 @@ export interface UploadOptions {
          */
         metadata?: Record<string, unknown>;
     };
+
+    /**
+     * whether this request should be sent with outgoing credentials (cookies)
+     */
+    withCredentials?: boolean;
 }
 ```
 
@@ -181,7 +186,7 @@ interface NgxFileUploadFactory {
 }
 ```
 
---- 
+---
 
 ## ValidationErrors
 

--- a/docs/core/factory.md
+++ b/docs/core/factory.md
@@ -46,7 +46,7 @@ export class MyComponent implements OnDestroy, OnInit {
      */
     public fileSelectOrDrop(file: File) {
 
-        const uploadRequest: NgxFileUploadRequest = 
+        const uploadRequest: NgxFileUploadRequest =
             this.uploadFactory.createUploadRequest(droppedFile, this.uploadOptions);
 
         this.uploadStorage.add(requests);
@@ -57,7 +57,7 @@ export class MyComponent implements OnDestroy, OnInit {
      */
     public multipleFiles(files: File[]) {
 
-        const uploadRequest: NgxFileUploadRequest[] = 
+        const uploadRequest: NgxFileUploadRequest[] =
             this.uploadFactory.createUploadRequest(files, this.uploadOptions);
 
         this.uploadStorage.add(requests);
@@ -96,9 +96,9 @@ export interface UploadOptions {
         /**
          * only used if FormData is enabled, defines the name which should used
          * in FormData
-         * 
+         *
          * @example
-         * 
+         *
          * // on server
          * req.files.picture;
          */
@@ -108,6 +108,10 @@ export interface UploadOptions {
      * add aditional headers to request
      */
     headers?: NgxFileUploadHeaders;
+    /**
+     * whether this request should be sent with outgoing credentials (cookies)
+     */
+    withCredentials?: boolean;
 }
 ```
 

--- a/docs/core/headers.md
+++ b/docs/core/headers.md
@@ -47,7 +47,7 @@ export class MyComponent implements OnDestroy, OnInit {
      */
     public multipleFiles(files: File[]) {
 
-        const uploadRequest: NgxFileUploadRequest[] = 
+        const uploadRequest: NgxFileUploadRequest[] =
             this.uploadFactory.createUploadRequest(files, this.uploadOptions);
 
         this.uploadStorage.add(requests);
@@ -74,7 +74,7 @@ interface AuthorizationHeader {
 
 there are 3 ways to pass an authorization header
 
-- passing a string value 
+- passing a string value
 
     ```ts
     /** upload options */
@@ -82,7 +82,7 @@ there are 3 ways to pass an authorization header
         url: "http://localhost:3000/upload/gallery",
         headers: {
             /**
-             * will send header: 
+             * will send header:
              *
              * Authorization: Bearer my-token
              */
@@ -101,7 +101,7 @@ there are 3 ways to pass an authorization header
             /**
              * pass an object, if no key is passed it will take Bearer by default
              * so this is the same as authorization: "my-token"
-             * 
+             *
              * Authorization: Bearer my-token
              */
             authorization: {token: "my-token" },
@@ -118,11 +118,26 @@ there are 3 ways to pass an authorization header
         headers: {
             /**
              * if you set an key this will be used as token name
-             * sends header: 
-             * 
+             * sends header:
+             *
              * Authorization: MyAuthToken my-token
              */
             authorization: {key: "MyAuthToken", token: "my-token" },
         }
     };
     ```
+
+
+## Send HTTP-only cookies
+
+Set `withCredentials` in the upload options when creating a request.
+
+### example
+
+```ts
+/** upload options */
+const uploadOptions: UploadOptions = {
+    url: "http://localhost:3000/upload/gallery",
+    withCredentials: true
+};
+```

--- a/src/projects/core/src/lib/api/src/upload.ts
+++ b/src/projects/core/src/lib/api/src/upload.ts
@@ -179,11 +179,16 @@ export interface NgxFileUploadOptions {
         /**
          * additional metadata which will append to formData, requires formData
          * to be enabled
-         * 
+         *
          * @deprecated use additionalData instead
          */
         metadata?: Record<string, unknown>;
     };
 
     headers?: NgxFileUploadHeaders;
+
+    /**
+     * if set to true will include HTTP-only cookies with the request
+     */
+    withCredentials?: boolean;
 }

--- a/src/projects/core/src/lib/upload/src/upload.request.ts
+++ b/src/projects/core/src/lib/upload/src/upload.request.ts
@@ -22,7 +22,8 @@ export class NgxFileUploadRequest implements INgxFileUploadRequest {
 
   private options: NgxFileUploadOptions = {
     url: "",
-    formData: { enabled: true, name: "file" }
+    formData: { enabled: true, name: "file" },
+    withCredentials: false,
   };
 
   private model: NgxFileUploadRequestModel;
@@ -197,14 +198,15 @@ export class NgxFileUploadRequest implements INgxFileUploadRequest {
     /**
      * save size on start so we do not call it every time
      * since this running a reduce loop, and the size will not change
-     * anymore after we start it 
+     * anymore after we start it
      */
     this.totalSize = this.model.size;
 
     return this.http.post<string>(this.options.url, uploadBody, {
       reportProgress: true,
+      withCredentials: this.options.withCredentials,
       observe: "events",
-      headers
+      headers,
     }).pipe(
       takeUntil(merge(this.cancel$, this.destroyed$))
     );
@@ -316,7 +318,7 @@ export class NgxFileUploadRequest implements INgxFileUploadRequest {
     this.model.state = NgxFileUploadState.PROGRESS;
 
     /**
-     * for some reason the upload is sometimes a bit bigger then the files, 
+     * for some reason the upload is sometimes a bit bigger then the files,
      * pretty sure this happens because of headers which are send makes the request a bit
      * bigger
      */

--- a/src/projects/core/src/tests/upload/upload.request.spec.ts
+++ b/src/projects/core/src/tests/upload/upload.request.spec.ts
@@ -188,7 +188,7 @@ describe("NgxFileUpload/libs/upload", () => {
     });
 
     it("should not start upload, is not pending or idle", () => {
-        const file = createNgxFileUploadFile() 
+        const file = createNgxFileUploadFile()
         const request = new NgxFileUploadRequest(httpClient, file, {url})
         request.state = NgxFileUploadState.PROGRESS
 
@@ -328,6 +328,17 @@ describe("NgxFileUpload/libs/upload", () => {
 
         expect(token).toEqual('12345')
         expect(name).toEqual('mocked')
+    });
+
+    it("should set withCredentials on request", () => {
+        const request = new NgxFileUploadRequest(httpClient, createNgxFileUploadFile(), {
+            url,
+            withCredentials: true
+        })
+        request.start();
+
+        const mockReq = httpMock.expectOne(url)
+        expect(mockReq.request.withCredentials).toEqual(true)
     });
 
     it("should remove invalid files", () => {


### PR DESCRIPTION
Closes #775.

Adds support for passing `withCredentials` in the options when calling `NgxFileUploadFactory.createUploadRequest()` to allow for HTTP-only cookies to be sent with upload requests if necessary.